### PR TITLE
PPS/WPS changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - [ ] Address all the build warnings
 - [ ] Improve command line operation
 - [ ] Profiling and perforfance tweaking
-- [ ] Implement new upstream protocols
+- [x] Implement new upstream protocols
 - [ ] Multi Pool Switching
 - [ ] Interface Improvement - Colour!
 
@@ -12,7 +12,7 @@
 ### Install dependencies
 
 ```sh
-sudo apt-get install build-essential libboost-all-dev install libdb-dev libdb++-dev libssl-dev libminiupnpc-dev libqrencode-dev qt4-qmake libqt4-dev libgmp3-dev
+sudo apt-get install build-essential libboost-all-dev libdb-dev libdb++-dev libssl-dev libminiupnpc-dev libgmp-dev
 ```
 
 ### Clone the repo
@@ -28,6 +28,23 @@ git clone https://github.com/Nexusoft/PrimePoolMiner.git PrimePoolMiner
 cd PrimePoolMiner
 make MARCHFLAGS=-march=native -f makefile.unix
 ```
+
+### miner.conf
+The pool miner can now be configured via miner.conf.
+You can adjust the parameters used to initialise the prime sieving / wheel factorisation to optimise the PPS/WPS for your CPU. 
+
+	"host": <the pool hostname / ipaddress to connect to> 
+	"port": <the pool port, default 9549>
+	"nxs_address": <your payout address>
+    "threads": <number of cores/threads to use, default is 0 (all available cores)
+	"timeout": <timeout when connecting to pool, default 10s>
+	"bit_array_size": <the size of the prime sieve in bytes, default 37748736. Adjust this to suit your CPU cache size> 
+	"prime_limit": <max prime number used to initialise the sieve, default 71378571>
+	"n_prime_limit": <max inverses prime limit, default 4194304>
+	"primorial_end_prime": <largest primorial, default 12>
+
+### Run the miner
+./nexus_cpuminer 
 
 # Original Message: 
 

--- a/config.h
+++ b/config.h
@@ -18,7 +18,7 @@ namespace Core
     public:
         MinerConfig();
         bool ReadConfig();
-	void PrintConfig();
+	    void PrintConfig();
 
 	// Standard config
         std::string  strHost;

--- a/core.h
+++ b/core.h
@@ -84,6 +84,7 @@ namespace LLP
 			SUBMIT_SHARE     = 2,
 			ACCOUNT_BALANCE  = 3,
 			PENDING_PAYOUT   = 4,
+			SUBMIT_PPS     	= 5,
 			
 					
 			/** REQUEST PACKETS **/
@@ -133,7 +134,22 @@ namespace LLP
 		
 		
 		/** Ping the Pool Server to let it know Connection is Still Alive. **/
-		inline void Ping() { this -> WritePacket(GetPacket(PING)); }
+		inline void SubmitPPS(double PPS, double WPS) 
+		{ 
+			Packet PACKET = GetPacket(SUBMIT_PPS);
+			std::vector<unsigned char> vPPSBytes = double2bytes(PPS);
+			std::vector<unsigned char> vWPSBytes = double2bytes(WPS);
+			// add PPS
+			PACKET.DATA.insert(PACKET.DATA.end(),vPPSBytes.begin(), vPPSBytes.end()  );
+			
+			// add WPS
+			PACKET.DATA.insert(PACKET.DATA.end(),vWPSBytes.begin(), vWPSBytes.end()  );
+
+			PACKET.LENGTH = PACKET.DATA.size();
+
+			this->WritePacket(PACKET);
+			
+		}
 		
 		
 		/** Send your address for Pool Login. **/

--- a/core.h
+++ b/core.h
@@ -132,8 +132,10 @@ namespace LLP
 		/** Get the Current Pending Payouts for the Next Coinbase Tx. **/
 		inline void GetPayouts()  { this -> WritePacket(GetPacket(GET_PAYOUT)); }
 		
-		
 		/** Ping the Pool Server to let it know Connection is Still Alive. **/
+		inline void Ping() { this -> WritePacket(GetPacket(PING)); }
+		
+		/** Send current PPS / WPS data to the pool **/
 		inline void SubmitPPS(double PPS, double WPS) 
 		{ 
 			Packet PACKET = GetPacket(SUBMIT_PPS);

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -25,7 +25,7 @@ LIBS= \
  -l gmpxx \
  -l gmp
 
-DEFS=-DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
+DEFS=-D__MINGW32__ -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
 CFLAGS=-static -static-libgcc -static-libstdc++ -O2 -w -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 LIBS +=-l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l shlwapi
@@ -41,7 +41,8 @@ OBJS= \
 	build/KeccakHash.o \
 	build/prime.o \
 	build/util.o \
-	build/miner.o 
+	build/miner.o \
+	build/config.o
 
 
 all: nexus_cpuminer.exe

--- a/makefile.unix
+++ b/makefile.unix
@@ -35,7 +35,8 @@ OBJS= \
 	build/KeccakHash.o \
 	build/util.o \
 	build/prime.o \
-	build/miner.o
+	build/miner.o \
+	build/config.o
 
 
 all: nexus_cpuminer

--- a/miner.conf
+++ b/miner.conf
@@ -1,7 +1,7 @@
 {
-	"host": "127.0.0.1",
+	"host": "nexusminingpool.com",
 	"port": "9549",
-	"nxs_address": "2RjohSoM34UazsV8iHxaFrJ5f6eeeohLWE83QkLYbHKNnBz1cND",
+	"nxs_address": "2Rdm4DNtqcvvWndxJANrwjVJSiVEYSJnC6DTcQCHwzYw5qFHoK1",
 	"threads": 0,
 	"timeout": 10,
 	"bit_array_size": 37748736,

--- a/miner.conf
+++ b/miner.conf
@@ -1,7 +1,7 @@
 {
 	"host": "nexusminingpool.com",
 	"port": "9549",
-	"nxs_address": "2Rdm4DNtqcvvWndxJANrwjVJSiVEYSJnC6DTcQCHwzYw5qFHoK1",
+	"nxs_address": "2SSbxVqakuEQeTLk8cgGKeWCiVrsyJtFMrvKxJDmuY3nRAmr2uJ",
 	"threads": 0,
 	"timeout": 10,
 	"bit_array_size": 37748736,

--- a/util.h
+++ b/util.h
@@ -5,9 +5,9 @@
 #include "hash/templates.h"
 #include "bignum.h"
 
-#if defined _WIN32 || defined WIN32
+#if (defined _WIN32 || defined WIN32) && !defined __MINGW32__
 	typedef int pid_t;
-#else
+#elif !defined __MINGW32__
 	#include <sys/types.h>
 	#include <sys/time.h>
 	#include <sys/resource.h>
@@ -96,6 +96,26 @@ inline std::string bytes2string(std::vector<unsigned char> BYTES)
 	return STRING;
 }
 
+inline std::vector<unsigned char> double2bytes(double DOUBLE)
+{
+    union {
+        double DOUBLE;
+        uint64 UINT64;
+    } u;
+    u.DOUBLE = DOUBLE;
 
+    return uint2bytes64(u.UINT64);
+}
+
+inline double bytes2double(std::vector<unsigned char> BYTES)
+{
+    uint64 n64 = bytes2uint64(BYTES);
+    union {
+        double DOUBLE;
+        uint64 UINT64;
+    } u;
+    u.UINT64 = n64;
+    return u.DOUBLE;
+}
 
 #endif


### PR DESCRIPTION
PPS and WPS are now 5-minute averages
WPS is now based on all >= 3-tuples found, irrespective of pool minimum share, giving a more accurate measure of current miner effectiveness
PPS and WPS are now submitted to the pool server in a new LLP message